### PR TITLE
refactor: change requireUpdatedMain to allowOutdatedBase for clarity

- Inverted logic to make safer behavior the default (false)
- Operations now fail by default if base branch is outdated
- Added --allow-outdated-base CLI flag to all relevant commands
- Updated all error messages to use 'base branch' terminology
- Updated documentation with new configuration option

BREAKING CHANGE: Config property renamed from requireUpdatedMain to allowOutdatedBase with inverted logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ Create `.slambed.json` in your project:
 {
   "gitFlow": {
     "defaultBranch": "main",
-    "autoMerge": true
+    "autoMerge": true,
+    "allowOutdatedBase": false
   },
   "automation": {
     "runFormat": true,
@@ -241,6 +242,39 @@ Create `.slambed.json` in your project:
     "runTests": false
   }
 }
+```
+
+### Configuration Options
+
+#### gitFlow.allowOutdatedBase (default: false)
+
+Controls whether operations can proceed when the base branch (main/master) is outdated:
+
+- `false` (default): Operations will fail if base branch is outdated and cannot be updated
+- `true`: Operations will continue with warnings even if base branch is outdated
+
+This is useful for:
+
+- **Offline work**: Set to `true` when working without network access
+- **CI environments**: May need `true` if CI has limited git access
+- **Strict workflows**: Keep as `false` to ensure all work starts from latest base
+
+Example scenarios:
+
+```bash
+# With allowOutdatedBase: false (default)
+$ slambed auto commit
+⚠️  Base branch (main) is 3 commits behind origin/main
+  Fetched latest main from origin
+  Attempting to update base branch...
+  ✅ Successfully updated base branch
+✓ Created branch: feature/add-authentication-2025-01-05
+
+# With allowOutdatedBase: true
+$ slambed auto commit
+⚠️  Base branch (main) is 3 commits behind origin/main
+⚠️  Could not update base branch due to network issue. Continuing anyway due to config...
+✓ Created branch: feature/add-authentication-2025-01-05
 ```
 
 ## 🛠️ Installation

--- a/bin/slamb-commit.js
+++ b/bin/slamb-commit.js
@@ -48,6 +48,7 @@ program
   .option("--no-format", "Skip formatting")
   .option("--no-lint", "Skip linting")
   .option("-t, --target <branch>", "Target branch", "main")
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .action(async (options) => {
     try {
       let message = options.message;
@@ -73,7 +74,21 @@ program
       console.log(`Target: ${options.target}`);
 
       // Call autoCommit function
-      console.log(chalk.green("✅ Workflow completed!"));
+      const result = await autoCommit({
+        message,
+        branch_name: options.branch,
+        auto_merge: options.merge,
+        run_format: options.format,
+        run_lint: options.lint,
+        target_branch: options.target,
+        allow_outdated_base: options.allowOutdatedBase,
+      });
+
+      console.log(
+        result.success
+          ? chalk.green(result.message)
+          : chalk.red(result.message),
+      );
     } catch (error) {
       console.error(chalk.red("Error:"), error.message);
       process.exit(1);
@@ -246,6 +261,7 @@ program
   .option("--no-lint", "Skip running linting")
   .option("--no-release", "Skip creating GitHub release")
   .option("--no-merge", "Skip auto-merging PR")
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .option("--dry-run", "Perform dry run without publishing")
   .option("--registry <url>", "NPM registry URL", "https://registry.npmjs.org/")
   .action(async (options) => {
@@ -295,6 +311,7 @@ program
         auto_merge_pr: options.merge,
         dry_run: options.dryRun,
         registry: options.registry,
+        allow_outdated_base: options.allowOutdatedBase,
       });
 
       console.log(

--- a/bin/slamb-flow.js
+++ b/bin/slamb-flow.js
@@ -38,10 +38,15 @@ program
     "Branch type (feature, fix, docs, chore)",
     "feature",
   )
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .action(async (name, options) => {
     try {
       console.log(chalk.blue(`Starting ${options.type} branch: ${name}`));
-      const result = await startBranch(name, options.type);
+      const result = await startBranch(
+        name,
+        options.type,
+        options.allowOutdatedBase,
+      );
       console.log(
         result.success
           ? chalk.green(result.message)

--- a/bin/slambed.js
+++ b/bin/slambed.js
@@ -159,6 +159,7 @@ automationCmd
     "Strategy for stale branches: auto, rebase, new",
     "auto",
   )
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .action(async (options) => {
     try {
       // Check if we need a message (auto-generate with AI by default)
@@ -206,6 +207,7 @@ automationCmd
         run_lint: options.lint,
         target_branch: options.target,
         branch_strategy: options.branchStrategy,
+        allow_outdated_base: options.allowOutdatedBase,
       });
 
       console.log(
@@ -303,6 +305,7 @@ automationCmd
   .option("--no-merge", "Skip auto-merging PR")
   .option("--dry-run", "Perform dry run without publishing")
   .option("--registry <url>", "NPM registry URL", "https://registry.npmjs.org/")
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .action(async (options) => {
     try {
       if (options.dryRun) {
@@ -337,6 +340,7 @@ automationCmd
         auto_merge_pr: options.merge,
         dry_run: options.dryRun,
         registry: options.registry,
+        allow_outdated_base: options.allowOutdatedBase,
       });
 
       console.log(
@@ -461,9 +465,14 @@ flowCmd
     "Branch type (feature, fix, docs, chore)",
     "feature",
   )
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .action(async (name, options) => {
     try {
-      const result = await startBranch(name, options.type);
+      const result = await startBranch(
+        name,
+        options.type,
+        options.allowOutdatedBase,
+      );
       console.log(
         result.success
           ? chalk.green(result.message)
@@ -589,11 +598,13 @@ program
   .description("Commit changes with smart workflow")
   .option("-m, --message <message>", "Commit message")
   .option("--no-merge", "Skip auto-merge")
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .action(async (options) => {
     try {
       const result = await autoCommit({
         message: options.message,
         auto_merge: options.merge,
+        allow_outdated_base: options.allowOutdatedBase,
       });
       console.log(
         result.success
@@ -659,11 +670,13 @@ program
   .description("Publish package to npm")
   .option("-v, --version <type>", "Version bump type", "patch")
   .option("--dry-run", "Perform dry run")
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
   .action(async (options) => {
     try {
       const result = await npmPublish({
         version_type: options.version,
         dry_run: options.dryRun,
+        allow_outdated_base: options.allowOutdatedBase,
       });
       console.log(
         result.success
@@ -692,9 +705,14 @@ program
 program
   .command("feature <name>")
   .description("Start a new feature branch")
-  .action(async (name) => {
+  .option("--allow-outdated-base", "Allow operations on outdated base branch")
+  .action(async (name, options) => {
     try {
-      const result = await startBranch(name, "feature");
+      const result = await startBranch(
+        name,
+        "feature",
+        options.allowOutdatedBase,
+      );
       console.log(
         result.success
           ? chalk.green(result.message)

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,7 @@ const DEFAULT_CONFIG = {
     branchStrategy: "auto", // auto | auto-fresh | reuse-with-check | always-reuse
     autoCleanupMerged: false, // Automatically cleanup merged branches before creating new ones
     warnOnMergedBranch: true, // Show warnings when working on merged branches
+    allowOutdatedBase: false, // When true, allows operations on outdated base branches
   },
 
   // Automation settings


### PR DESCRIPTION
## Summary
refactor: change requireUpdatedMain to allowOutdatedBase for clarity

- Inverted logic to make safer behavior the default (false)
- Operations now fail by default if base branch is outdated
- Added --allow-outdated-base CLI flag to all relevant commands
- Updated all error messages to use 'base branch' terminology
- Updated documentation with new configuration option

BREAKING CHANGE: Config property renamed from requireUpdatedMain to allowOutdatedBase with inverted logic

## Changes Made
- Auto-generated commit with formatting and linting
- Ready for review and merge

## Testing
- [ ] Code formatting applied
- [ ] Linting checks passed
- [ ] Manual testing completed

🤖 Generated with [Slambed MCP](https://github.com/your-username/slambed-mcp)